### PR TITLE
* initialSelection can be one of code OR dial_code

### DIFF
--- a/lib/country_code_picker.dart
+++ b/lib/country_code_picker.dart
@@ -45,7 +45,10 @@ class _CountryCodePickerState extends State<CountryCodePicker> {
   initState() {
     if (widget.initialSelection != null) {
       selectedItem = elements.firstWhere(
-          (e) => e.code.toUpperCase() == widget.initialSelection.toUpperCase(),
+          (e) {
+            e.code.toUpperCase() == widget.initialSelection.toUpperCase() ||
+                e.dialCode == widget.initialSelection.toString();
+          },
           orElse: () => elements[0]);
     } else {
       selectedItem = elements[0];


### PR DESCRIPTION
onChanged callback returns code so there is no way to set selectedCode on State Change in parent widget.