### PR TITLE
Fix SamsungSmartSuggestion crash

### DIFF
--- a/lib/selection_dialog.dart
+++ b/lib/selection_dialog.dart
@@ -92,7 +92,7 @@ class _SelectionDialogState extends State<SelectionDialog> {
               if (!widget.hideSearch)
                 Padding(
                   padding: const EdgeInsets.symmetric(horizontal: 24),
-                  child: TextField(
+                  child: TextFormField(
                     style: widget.searchStyle,
                     decoration: widget.searchDecoration,
                     onChanged: _filterElements,


### PR DESCRIPTION
Fixing a crash on Samsung Android devices that uses `SamsungSmartSuggestion`.

Fixed according to this comment:
[https://github.com/flutter/flutter/issues/98505#issuecomment-1067976038](url)

![screenshot](https://user-images.githubusercontent.com/101117824/160781798-b8253e68-bedf-4f60-90cb-8d88538bbbb6.jpeg)
 