### PR TITLE
⬆️ Upgrade modal_bottom_sheet 2.0.1 to support Flutter 3.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  modal_bottom_sheet: ^2.0.0
+  modal_bottom_sheet: ^2.0.1
   collection: ^1.15.0
   universal_platform: ^1.0.0+1
 


### PR DESCRIPTION
Fix deprecated VelocityTracker issue in Flutter 3.0

![image](https://user-images.githubusercontent.com/8846657/167983606-d92b80dc-4e53-41ba-927b-dc53dc8a2270.png)
