### PR TITLE
Fix compilation issue with Flutter 3

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  modal_bottom_sheet: ^2.0.0
+  modal_bottom_sheet: ^2.0.1
   collection: ^1.15.0
   universal_platform: ^1.0.0+1
 


### PR DESCRIPTION
There's a compilation issue with flutter 3:

```console
pub.dartlang.org/modal_bottom_sheet-2.0.0/lib/src/bottom_sheet.dart:303:28: Error: Couldn't find constructor 'VelocityTracker'.
```

https://github.com/jamesblasco/modal_bottom_sheet/issues/223#issuecomment-1062768155

This should fix it